### PR TITLE
Add HTTP_TIMEOUT envvar, which can be used to alter uwsgi http-timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ENV KAKADU_APPS_LOCATION s3://dlcs-dlcservices-bootstrap-objects/kdu77-apps.tar.
 ENV APPETISER_DIR /opt/appetiser
 ENV TMPDIR $APPETISER_DIR/tmp
 ENV OUTPUT_DIR $APPETISER_DIR/out/
+ENV HTTP_TIMEOUT 60
 
 RUN apt-get update -y && apt-get install -y cmake \
                                             netpbm \
@@ -21,6 +22,7 @@ RUN apt-get update -y && apt-get install -y cmake \
                                             python3-tk \
                                             libharfbuzz-dev \
                                             libfribidi-dev
+
 
 COPY . $APPETISER_DIR
 RUN chmod +x $APPETISER_DIR/run_tests.sh

--- a/run_appetiser.sh
+++ b/run_appetiser.sh
@@ -9,4 +9,4 @@ export KDU_EXPAND=/usr/local/bin/kdu_expand
 export KDU_LIB=/usr/local/bin
 
 cd $APPETISER_DIR
-uwsgi --http 0.0.0.0:80 --master --need-app --module appetiser:appetiser --processes 5
+uwsgi --http 0.0.0.0:80 --master --need-app --module appetiser:appetiser --processes 5 --http-timeout $HTTP_TIMEOUT


### PR DESCRIPTION
Defaults to 60 if not set (60s is the uwsgi default value)