### PR TITLE
Handle alternative image_modes

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -7,27 +7,18 @@ on:
     tags:
       - "*"
   pull_request:
+  
 jobs:
   build-push:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Extract branch name for push
-        run: echo "normalized_branch_name=$(stripped=${GITHUB_REF##*/} && echo ${stripped/\//-})" >> $GITHUB_ENV
-        if: github.event_name == 'push'
-
-      - name: Extract branch name for pull request
-        run: echo "normalized_branch_name=$(stripped=${PR_REF#refs/heads/} && echo ${stripped/\//-})" >> $GITHUB_ENV
-        if: github.event_name == 'pull_request'
-        env:
-          PR_REF: ${{ github.event.pull_request.head.ref }}
-
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -36,14 +27,26 @@ jobs:
 
       - name: Check out code
         id: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/dlcs/appetiser
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,enable=true,prefix=,format=long
 
       - name: Build and push
         id: docker_build
@@ -52,6 +55,5 @@ jobs:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
           push: true
-          tags: |
-            ghcr.io/dlcs/appetiser:${{ github.sha }}
-            ghcr.io/dlcs/appetiser:${{ env.normalized_branch_name }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          tags: ${{ steps.docker_meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-stretch
+FROM python:3.10-slim-bullseye
 
 ENV KAKADU_APPS_LOCATION s3://dlcs-dlcservices-bootstrap-objects/kdu77-apps.tar.gz
 ENV APPETISER_DIR /opt/appetiser

--- a/app/jp2/image.py
+++ b/app/jp2/image.py
@@ -102,7 +102,7 @@ def _uncompress_tiff(filepath: pathlib.Path) -> (pathlib.Path, dict):
 
         img_mode = img_info.get('mode')
         if img_mode not in image_modes:
-            logger.debug('%s: has unknown image mode.', filepath, img_mode)
+            logger.debug('%s: has unknown image mode: %s', filepath, img_mode)
             return _convert_tiff_mode(filepath, img, img_info)
 
     return filepath, img_info

--- a/app/jp2/image.py
+++ b/app/jp2/image.py
@@ -8,6 +8,8 @@ from PIL import (
     ImageCms,
 )
 
+from .kdu import image_modes
+
 logger = logging.getLogger(__name__)
 
 # Allows images of any size to be processed without raising a
@@ -63,6 +65,18 @@ def _uncompress_tiff(filepath: pathlib.Path) -> (pathlib.Path, dict):
             logger.debug('%s: saving as raw to %s', filepath, tiff_filepath)
             img.save(tiff_filepath, compression=None)
             filepath = tiff_filepath
+
+        img_mode = img_info.get('mode')
+        if img_mode not in image_modes:
+            logger.debug('%s: is not a known image mode.', img_mode)
+            img_filename = img.filename
+            updated_img = _convert_img_colour_profile(img, img_filename)
+            tiff_filepath = filepath.parent / ('raw_' + filepath.name)
+            logger.debug('%s: saving as raw to %s', filepath, tiff_filepath)
+            updated_img.save(tiff_filepath, compression=None)
+            filepath = tiff_filepath
+            img_info['mode'] = updated_img.mode
+
     return filepath, img_info
 
 

--- a/app/jp2/image.py
+++ b/app/jp2/image.py
@@ -210,7 +210,7 @@ def prepare_source_file(filepath: pathlib.Path) -> (pathlib.Path, dict):
         '.tif': _uncompress_tiff,
         '.tiff': _uncompress_tiff,
     }
-    f = img_file_funcs.get(filepath.suffix, _convert_img_to_tiff)
+    f = img_file_funcs.get(filepath.suffix.lower(), _convert_img_to_tiff)
     logger.debug('%s() to be applied to %s', f.__name__, filepath)
     return f(filepath)
 

--- a/app/jp2/kdu.py
+++ b/app/jp2/kdu.py
@@ -19,6 +19,13 @@ logger = logging.getLogger(__name__)
 # warning or an error.
 Image.MAX_IMAGE_PIXELS = None
 
+image_modes = {
+    'L': '-no_palette',
+    '1': '-no_palette',
+    'RGB': '-jp2_space sRGB',
+    'RGBA': '-jp2_space sRGB -jp2_alpha'
+}
+
 
 def _run_kdu_command(kdu_command: str, env: dict):
     try:
@@ -39,13 +46,6 @@ def kdu_compress(source_path: pathlib.Path, dest_path: pathlib.Path,
     """ Uses the kdu_compress command to convert a source image
         (in BMP, RAW, PBM, PGM, PPM or TIFF formats) to a JPEG2000.
         """
-
-    image_modes = {
-        'L': '-no_palette',
-        '1': '-no_palette',
-        'RGB': '-jp2_space sRGB',
-        'RGBA': '-jp2_space sRGB -jp2_alpha'
-    }
 
     if image_mode not in image_modes:
         logger.warning(f"image_mode '{image_mode}' is not in known list")

--- a/app/jp2/kdu.py
+++ b/app/jp2/kdu.py
@@ -22,6 +22,7 @@ Image.MAX_IMAGE_PIXELS = None
 image_modes = {
     'L': '-no_palette',
     '1': '-no_palette',
+    'I;16B': '-no_palette',
     'RGB': '-jp2_space sRGB',
     'RGBA': '-jp2_space sRGB -jp2_alpha'
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 awscli==1.25.53
 Flask==2.2.2
-Pillow==9.2.0
+Pillow==9.3.0
 pytest==7.1.2
 pytest-mock==3.8.2
 uwsgi==2.0.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 awscli==1.25.53
 Flask==2.2.2
-Pillow==9.3.0
+Pillow==9.4.0
 pytest==7.1.2
 pytest-mock==3.8.2
 uwsgi==2.0.20


### PR DESCRIPTION
Handle alternative image_modes - predominately CMYK. Outline of changes:

* in `_uncompress_tiff` check if the image_mode is a known type. If not:
  * Call `_convert_img_colour_profile` to change it to RGB and save
  * Write new file to stream + reload to get as `PIL.TiffImagePlugin.TiffImageFile` and access to tags
  * Check if XResolution and YResolution tags are present, if not set values from source image (unsure why these are being dropped).
  * Save to disk

Other changes:
* Add `I;16B` to known image_types. KDU handles these okay but Pillow only has limited support, conversion results in distorted image.
* When looking up dict for image type, call `.lower()` on suffix to handle, e.g. `.TIF` as `.tif`.
* Update base docker image and Pillow dependency