### PR TITLE
Update pypi deps

### DIFF
--- a/app/jp2/image.py
+++ b/app/jp2/image.py
@@ -249,7 +249,7 @@ def resize_and_save_img(img: Image, size: int, dest_path: pathlib.Path) -> Image
         """
     scaled_width, scaled_height = _scale_dimensions_to_fit(
         img.width, img.height, size, size)
-    img = img.resize((scaled_width, scaled_height), resample=Image.ANTIALIAS)
+    img = img.resize((scaled_width, scaled_height), resample=Image.LANCZOS)
     logger.debug('Image resized to (%s, %s)', scaled_width, scaled_height)
     img.save(dest_path, quality=90)
     logger.debug('Resized image saved to: %s', dest_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-awscli==1.25.53
-Flask==2.2.2
-Pillow==9.4.0
-pytest==7.1.2
-pytest-mock==3.8.2
-uwsgi==2.0.20
+awscli==1.31.9
+Flask==2.3.2
+Pillow==10.1.0
+pytest==7.4.3
+pytest-mock==3.12.0
+uwsgi==2.0.23


### PR DESCRIPTION
`ANTIALIAS` const was removed from PILLOW and replaced with `ANCZOS`, see https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants