### PR TITLE
Update scaling to ensure parity with dotnet output

### DIFF
--- a/appetiser/convert/image.py
+++ b/appetiser/convert/image.py
@@ -253,29 +253,28 @@ def scale_dimensions_to_fit(
 
     dec_width = decimal.Decimal(width)
     dec_height = decimal.Decimal(height)
-    width_scale = decimal.Decimal(0.0)
-    if req_width:
+
+    if req_width and req_height:
+        # this is confined - we don't support mutation
         dec_req_width = decimal.Decimal(req_width)
-        width_scale = dec_req_width / dec_width
-
-    height_scale = decimal.Decimal(0.0)
-    if req_height:
         dec_req_height = decimal.Decimal(req_height)
-        height_scale = dec_req_height / dec_height
+        scale = min(dec_req_width / dec_width, dec_req_height / dec_height)
+        scaled_width = int((dec_width * scale).to_integral_exact())
+        scaled_height = int((dec_height * scale).to_integral_exact())
 
-    if not height_scale and width_scale:
-        height_scale = width_scale
-    if not width_scale and height_scale:
-        width_scale = height_scale
+        logger.debug(
+            f"Confined. Final: ({scaled_width=}. {scaled_height=}). Params: ({scale=}. {width=}, {height=}, {req_width=}, {req_height=})",
+        )
+
+        return scaled_width, scaled_height
+
+    # if we are here we have width OR height
+    final_width = int(req_width if req_width else width * req_height / dec_height)
+    final_height = int(req_height if req_height else height * req_width / dec_width)
     logger.debug(
-        f"Scale factor calculated as: ({width_scale=}, {height_scale=}, {width=}, {height=}, {req_width=}, {req_height=})",
+        f"Single dimension. Final: ({final_width=}. {final_height=}). Params: {width=}, {height=}, {req_width=}, {req_height=})",
     )
-    scaled_int_width = int((dec_width * width_scale).to_integral_exact())
-    scaled_int_height = int((dec_height * height_scale).to_integral_exact())
-    logger.debug(
-        f"Scaled image dimensions: ({dec_width=}, {dec_height=}, {scaled_int_width=}, {scaled_int_height=})",
-    )
-    return scaled_int_width, scaled_int_height
+    return final_width, final_height
 
 
 def resize_and_save_img(


### PR DESCRIPTION
In production use, noticed that there are differences between the sizes calculated by the `iiif-net` dotnet library used by Protagonist and the sizes calculated by Appetiser.

Altered the `scaled_dimensions_to_fit()` function to use method from "old" Appetiser equivalent function https://github.com/dlcs/appetiser/blob/1.5.0/app/jp2/image.py#L218-L241 and used similar handling to dotnet code for `w,` and `,h`.

For reference the dotnet lib functions are:
* https://github.com/digirati-co-uk/iiif-net/blob/main/src/IIIF/IIIF/Size.cs#L126-L139 (in this case these are for for `w,` and `,h`)
* https://github.com/digirati-co-uk/iiif-net/blob/main/src/IIIF/IIIF/Size.cs#L111-L120 (for `!w,h`).

> [!NOTE]
> How can we extend the test suite to allow us to test this function to ensure any future changes don't break anything (e.g. if we allow mutating size-parameters?

-----------------
@tomcrane conducted some tests: https://github.com/tomcrane/appetiserscale/blob/main/8-b-numbers.txt to check fix, based on https://github.com/tomcrane/appetiserscale/blob/main/test.py#L80